### PR TITLE
Chunk loading system 5: chunk loading system #84

### DIFF
--- a/src/main/java/tanks/Chunk.java
+++ b/src/main/java/tanks/Chunk.java
@@ -324,20 +324,8 @@ public class Chunk implements Comparable<Chunk>
             t.add(o);
     }
 
-    public static Tile getTile(double x, double y)
-    {
-        return getTile((int) (x / Game.tile_size), (int) (y / Game.tile_size));
-    }
-
-    public static Tile getTile(int x, int y)
-    {
-        if (x < 0 || y < 0 || x >= Game.currentSizeX || y >= Game.currentSizeY)
-            return null;
-        return Game.tiles[x][y];
-    }
-
     /** Expects tile coordinates. */
-    public static Tile getTile2(int tileX, int tileY)
+    public static Tile getTile(int tileX, int tileY)
     {
         Chunk c = getChunk(tileX, tileY);
         if (c == null)
@@ -346,7 +334,7 @@ public class Chunk implements Comparable<Chunk>
     }
 
     /** Expects pixel coordinates. */
-    public static Tile getTile2(double posX, double posY)
+    public static Tile getTile(double posX, double posY)
     {
         Chunk c = getChunk(posX, posY);
         if (c == null)
@@ -408,14 +396,18 @@ public class Chunk implements Comparable<Chunk>
                 i += 1;
             }
         }
+
+        Drawing.drawing.setColor(255, 255, 255);
+        for (Movable m : Game.movables)
+            Drawing.drawing.drawText(m.posX, m.posY, m.getTouchingChunks().size() + "");
     }
 
     /** Given a rectangle's bounding box, clamps it to the level borders and draws it.
      * Also ensures a line width of 2. */
     private static void drawClampedRect(Level l, double x1, double y1, double x2, double y2)
     {
-        double sX = Math.max(2, Math.min(l.sizeX * Game.tile_size - x1, x2 - x1));
-        double sY = Math.max(2, Math.min(l.sizeY * Game.tile_size - y1, y2 - y1));
+        double sX = Math.max(1, Math.min(l.sizeX * Game.tile_size - x1, x2 - x1));
+        double sY = Math.max(1, Math.min(l.sizeY * Game.tile_size - y1, y2 - y1));
         Drawing.drawing.fillRect(x1 + sX / 2, y1 + sY / 2, sX, sY);
     }
 
@@ -431,24 +423,6 @@ public class Chunk implements Comparable<Chunk>
 
     public static void populateChunks(Level l, boolean clear)
     {
-        Game.tiles = new Tile[l.sizeX][l.sizeY];
-
-        int var = Game.fancyTerrain ? 1 : 0;
-
-        Random tilesRandom = new Random(l.tilesRandomSeed);
-        for (int i = 0; i < l.sizeX; i++)
-        {
-            for (int j = 0; j < l.sizeY; j++)
-            {
-                Tile t = new Tile();
-                t.colR = l.color.red + var * tilesRandom.nextDouble() * l.colorVar.red;
-                t.colG = l.color.green + var * tilesRandom.nextDouble() * l.colorVar.green;
-                t.colB = l.color.blue + var * tilesRandom.nextDouble() * l.colorVar.blue;
-                t.depth = Game.enable3dBg ? tilesRandom.nextDouble() * TILE_DEPTH_VARIATION * var : 0;
-                Game.tiles[i][j] = t;
-            }
-        }
-
         if (clear)
         {
             chunks.clear();
@@ -551,10 +525,7 @@ public class Chunk implements Comparable<Chunk>
 
             Face[] faces = s.getFaces();
             for (int i = 0; i < 4; i++)
-            {
-                if (faces[i].lastValid)
-                    getSide(i).remove(faces[i]);
-            }
+                getSide(i).remove(faces[i]);
         }
 
         public ObjectAVLTreeSet<Face> getSide(int side)

--- a/src/main/java/tanks/DebugKeybinds.java
+++ b/src/main/java/tanks/DebugKeybinds.java
@@ -169,7 +169,11 @@ public class DebugKeybinds
 
             if (Game.game.window.pressedKeys.contains(InputCodes.KEY_1))
             {
-                Chunk.Tile t1 = Chunk.getTile2(posX, posY);
+                Chunk c = Chunk.getChunk(posX, posY);
+                Chunk.Tile t1 = Chunk.getTile(posX, posY);
+
+                if (c != null)
+                    text += " C: (" + c.chunkX + ", " + c.chunkY + ")";
 
                 if (t1 != null)
                 {

--- a/src/main/java/tanks/Effect.java
+++ b/src/main/java/tanks/Effect.java
@@ -16,32 +16,18 @@ public class Effect extends Movable implements IDrawableWithGlow, IBatchRenderab
     public enum State {live, removed, recycle}
 
     public EffectType type;
-    public double age = 0;
-    public double colR;
-    public double colG;
-    public double colB;
+    public double colR, colG, colB;
 
     public boolean force = false;
     public boolean enableGlow = true;
-    public double glowR;
-    public double glowG;
-    public double glowB;
+    public double glowR, glowG, glowB;
 
     public double maxAge = 100;
-    public double size;
-    public double radius;
-    public double angle;
-    public double distance;
+    public double size, radius, angle, distance;
 
-    public int prevGridX;
-    public int prevGridY;
-
-    public int initialGridX;
-    public int initialGridY;
-
+    public int prevGridX, prevGridY;
+    public int initialGridX, initialGridY;
     public Movable linkedMovable;
-
-    public double[] lightInfo = new double[7];
 
     //Effects that have this set to true are removed faster when the level has ended
     public boolean fastRemoveOnExit = false;
@@ -50,9 +36,9 @@ public class Effect extends Movable implements IDrawableWithGlow, IBatchRenderab
 
     public static Effect createNewEffect(double x, double y, double z, EffectType type)
     {
-        while (Game.recycleEffects.size() > 0)
+        while (!Game.recycleEffects.isEmpty())
         {
-            Effect e = Game.recycleEffects.remove();
+            Effect e = Game.recycleEffects.poll();
 
             if (e.state == State.recycle)
             {
@@ -64,6 +50,13 @@ public class Effect extends Movable implements IDrawableWithGlow, IBatchRenderab
 
         Effect e = new Effect();
         e.initialize(x, y, z, type);
+        return e;
+    }
+
+    public static Effect createNewEffect(double x, double y, double z, EffectType type, double age)
+    {
+        Effect e = Effect.createNewEffect(x, y, z, type);
+        e.age = age;
         return e;
     }
 
@@ -115,7 +108,12 @@ public class Effect extends Movable implements IDrawableWithGlow, IBatchRenderab
             this.force = true;
         }
         else if (type == EffectType.laser)
+        {
             this.maxAge = 21;
+            this.colR = 255;
+            this.colG = 0;
+            this.colB = 0;
+        }
         else if (type == EffectType.piece)
             this.maxAge = Math.random() * 100 + 50;
         else if (type == EffectType.obstaclePiece)
@@ -322,7 +320,7 @@ public class Effect extends Movable implements IDrawableWithGlow, IBatchRenderab
         else if (this.type == EffectType.laser)
         {
             double size = Bullet.bullet_size - this.age / 2;
-            drawing.setColor(255, 0, 0);
+            drawing.setColor(colR, colG, colB);
 
             if (Game.enable3d)
                 drawing.fillOval(this.posX, this.posY, this.posZ, size, size);
@@ -647,6 +645,54 @@ public class Effect extends Movable implements IDrawableWithGlow, IBatchRenderab
         }
     }
 
+    public Effect setColor(double r, double g, double b)
+    {
+        this.colR = r;
+        this.colG = g;
+        this.colB = b;
+        return this;
+    }
+
+    public Effect setColor(double r, double g, double b, double noise)
+    {
+        this.colR = r + (Math.random() - 0.5) * noise;
+        this.colG = g + (Math.random() - 0.5) * noise;
+        this.colB = b + (Math.random() - 0.5) * noise;
+        return this;
+    }
+
+    public Effect setGlowColor(double r, double g, double b)
+    {
+        this.glowR = r;
+        this.glowG = g;
+        this.glowB = b;
+        return this;
+    }
+
+    public Effect setGlowEnabled(boolean enabled)
+    {
+        this.enableGlow = enabled;
+        return this;
+    }
+
+    public Effect setRadius(double radius)
+    {
+        this.radius = radius;
+        return this;
+    }
+
+    public Effect setSize(double size)
+    {
+        this.size = size;
+        return this;
+    }
+
+    @Override
+    public double getSize()
+    {
+        return size;
+    }
+
     public void drawGlow()
     {
         if (this.maxAge > 0 && this.maxAge < this.age)
@@ -801,11 +847,12 @@ public class Effect extends Movable implements IDrawableWithGlow, IBatchRenderab
             }
         }
 
+        int x = (int) (this.posX / Game.tile_size);
+        int y = (int) (this.posY / Game.tile_size);
+        Chunk.Tile t = Chunk.getTile(x, y), prevTile = Chunk.getTile(prevGridX, prevGridY);
+
         if (this.type == EffectType.obstaclePiece3d)
         {
-            int x = (int) (this.posX / Game.tile_size);
-            int y = (int) (this.posY / Game.tile_size);
-
             boolean collidedX = false;
             boolean collidedY = false;
             boolean collided;
@@ -826,9 +873,9 @@ public class Effect extends Movable implements IDrawableWithGlow, IBatchRenderab
 
             if (!(collidedX || collidedY))
             {
-                collided = this.posZ <= Game.sampleObstacleHeight(posX, posY);
+                collided = this.posZ <= t.height();
 
-                if (collided && prevGridX >= 0 && prevGridX < Game.currentSizeX && prevGridY >= 0 && prevGridY < Game.currentSizeY && Game.sampleObstacleHeight(posX, posY) != Game.sampleObstacleHeight(prevGridX, prevGridY))
+                if (collided && prevGridX >= 0 && prevGridX < Game.currentSizeX && prevGridY >= 0 && prevGridY < Game.currentSizeY && t.height() != prevTile.height())
                 {
                     collidedX = this.prevGridX != x;
                     collidedY = this.prevGridY != y;
@@ -870,10 +917,10 @@ public class Effect extends Movable implements IDrawableWithGlow, IBatchRenderab
                     this.posY = this.posY - dist;
                 }
 
-                if (!collidedX && !collidedY && (x != this.initialGridX || y != initialGridY) && Math.abs(this.posZ - Game.sampleObstacleHeight(posX, posY)) < Game.tile_size / 2)
+                if (!collidedX && !collidedY && (x != this.initialGridX || y != initialGridY) && Math.abs(this.posZ - t.height()) < Game.tile_size / 2)
                 {
                     this.vZ = -0.6 * this.vZ;
-                    this.posZ = (2 * Game.sampleObstacleHeight(posX, posY) - this.posZ);
+                    this.posZ = (2 * t.height() - this.posZ);
                 }
             }
 
@@ -884,23 +931,23 @@ public class Effect extends Movable implements IDrawableWithGlow, IBatchRenderab
         {
             if (Math.random() < Panel.frameFrequency * Game.effectMultiplier * 0.1)
             {
+                Effect e;
                 if (Game.enable3d)
                 {
-                    Effect e = Effect.createNewEffect(this.posX + (Math.random() - 0.5) * Game.tile_size, this.posY + (Math.random() - 0.5) * Game.tile_size, this.posZ, EffectType.piece);
+                    e = Effect.createNewEffect(this.posX + (Math.random() - 0.5) * Game.tile_size, this.posY + (Math.random() - 0.5) * Game.tile_size, this.posZ, EffectType.piece);
                     e.colR = 255;
                     e.colG = Math.random() * 255;
                     e.colB = 0;
                     e.vZ = Math.random() + 1;
-                    Game.addEffects.add(e);
                 }
                 else
                 {
-                    Effect e = Effect.createNewEffect(this.posX + (Math.random() - 0.5) * Game.tile_size, this.posY + (Math.random() - 0.5) * Game.tile_size, EffectType.piece);
+                    e = Effect.createNewEffect(this.posX + (Math.random() - 0.5) * Game.tile_size, this.posY + (Math.random() - 0.5) * Game.tile_size, EffectType.piece);
                     e.colR = 255;
                     e.colG = Math.random() * 255;
                     e.colB = 0;
-                    Game.addEffects.add(e);
                 }
+                Game.addEffects.add(e);
             }
 
             if (Game.enable3d && Math.random() < Panel.frameFrequency * Game.effectMultiplier * 0.1 * (2 - this.posZ / Game.tile_size))

--- a/src/main/java/tanks/GameObject.java
+++ b/src/main/java/tanks/GameObject.java
@@ -105,6 +105,33 @@ public abstract class GameObject
         return secondaryMetadataField.get(this.getClass());
     }
 
+    static double pi_over_4 = Math.PI / 4;
+    static double fastAtan(double a)
+    {
+        if (a < -1 || a > 1)
+            return Math.atan(a);
+
+        return pi_over_4 * a - a * (Math.abs(a) - 1) * (0.2447 + 0.0663 * Math.abs(a));
+    }
+
+    public static double getPolarDirection(double x, double y)
+    {
+        double angle = 0;
+        if (x > 0)
+            angle = Math.atan(y / x);
+        else if (x < 0)
+            angle = Math.atan(y / x) + Math.PI;
+        else
+        {
+            if (y > 0)
+                angle = Math.PI / 2;
+            else if (y < 0)
+                angle = Math.PI * 3 / 2;
+        }
+
+        return angle;
+    }
+
     public static double distanceBetween(double x1, double y1, double x2, double y2)
     {
         return Math.sqrt(sqDistBetw(x1, y1, x2, y2));

--- a/src/main/java/tanks/Level.java
+++ b/src/main/java/tanks/Level.java
@@ -1,19 +1,27 @@
 package tanks;
 
 import basewindow.Color;
-import main.Tanks;
-import tanks.gui.screen.*;
+import tanks.gui.screen.ILevelPreviewScreen;
+import tanks.gui.screen.ScreenGame;
+import tanks.gui.screen.ScreenPartyHost;
+import tanks.gui.screen.ScreenPartyLobby;
 import tanks.gui.screen.leveleditor.ScreenLevelEditor;
 import tanks.gui.screen.leveleditor.ScreenLevelEditorOverlay;
 import tanks.gui.screen.leveleditor.selector.SelectorTeam;
 import tanks.item.Item;
-import tanks.network.event.*;
+import tanks.network.event.EventEnterLevel;
+import tanks.network.event.EventLoadLevel;
+import tanks.network.event.EventTankRemove;
+import tanks.network.event.INetworkEvent;
 import tanks.obstacle.Obstacle;
 import tanks.obstacle.ObstacleBeatBlock;
 import tanks.registry.RegistryTank;
 import tanks.tank.*;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Random;
 
 public class Level
 {
@@ -514,17 +522,17 @@ public class Level
 			Game.movables.remove(Game.playerTank);
 		}
 
-		this.reloadTiles();
+		for (Obstacle o : obstacles)
+            Game.addObstacle(o, false);
 
-		for (Obstacle o : obstacles) {
-			Game.addObstacle(o, false);
-		}
-
-		for (Tank t : tanks) {
+		for (Tank t : tanks)
+        {
 			if (sc != null)
 				t.drawAge = 50;
 			Game.movables.add(t);
 		}
+
+		this.reloadTiles();
 
 		this.availablePlayerSpawns.clear();
 
@@ -780,8 +788,22 @@ public class Level
 		Chunk.populateChunks(Game.currentLevel);
 		addLevelBorders();
 
-		for (Obstacle o: Game.obstacles)
+		for (Obstacle o : Game.obstacles)
+		{
             o.postOverride();
+
+			Chunk c = Chunk.getChunk(o.posX, o.posY);
+			if (c != null)
+				c.addObstacle(o, false);
+
+			if (o.update)
+				Game.obstaclesToUpdate.add(o);
+		}
+
+		for (Movable m : Game.movables)
+            m.refreshFaces = true;
+		for (Obstacle o : Game.obstacles)
+			o.refreshHitboxes();
 
 		ScreenLevelEditor s = null;
 

--- a/src/main/java/tanks/SolidGameObject.java
+++ b/src/main/java/tanks/SolidGameObject.java
@@ -17,9 +17,9 @@ public abstract class SolidGameObject extends GameObject implements ISolidObject
         return this.faces;
     }
 
-    public boolean isFaceValid(Face f)
+    public boolean isFaceValid(Face ignored)
     {
-        return !Double.isNaN(posX) && !Double.isNaN(posY);
+        return !Double.isNaN(posX) && !Double.isNaN(posY) && (tankCollision() || bulletCollision());
     }
 
     public void updateFaces()
@@ -27,7 +27,7 @@ public abstract class SolidGameObject extends GameObject implements ISolidObject
         if (this.faces == null)
             this.faces = new Face[4];
 
-        if (this.faces[0] == null || !Game.immutableFaces)
+        if (this.faces[0] == null || Game.immutableFaces)
         {
             for (int i = 0; i < 4; i++)
                 this.faces[i] = new Face(this, Direction.fromIndex(i), tankCollision(), bulletCollision());
@@ -58,49 +58,5 @@ public abstract class SolidGameObject extends GameObject implements ISolidObject
     public boolean bulletCollision()
     {
         return true;
-    }
-
-    // deprecated, will be removed in next PR
-    public Face[] horizontalFaces;
-    public Face[] verticalFaces;
-
-    @Override
-    public Face[] getHorizontalFaces()
-    {
-        double s = getSize() / 2;
-
-        if (this.horizontalFaces == null)
-        {
-            this.horizontalFaces = new Face[2];
-            this.horizontalFaces[0] = new Face(this, this.posX - s, this.posY - s, this.posX + s, this.posY - s, true, true, true, true);
-            this.horizontalFaces[1] = new Face(this, this.posX - s, this.posY + s, this.posX + s, this.posY + s, true, false,true, true);
-        }
-        else
-        {
-            this.horizontalFaces[0].update(this.posX - s, this.posY - s, this.posX + s, this.posY - s);
-            this.horizontalFaces[1].update(this.posX - s, this.posY + s, this.posX + s, this.posY + s);
-        }
-
-        return this.horizontalFaces;
-    }
-
-    @Override
-    public Face[] getVerticalFaces()
-    {
-        double s = getSize() / 2;
-
-        if (this.verticalFaces == null)
-        {
-            this.verticalFaces = new Face[2];
-            this.verticalFaces[0] = new Face(this, this.posX - s, this.posY - s, this.posX - s, this.posY + s, false, true, true, true);
-            this.verticalFaces[1] = new Face(this, this.posX + s, this.posY - s, this.posX + s, this.posY + s, false, false, true, true);
-        }
-        else
-        {
-            this.verticalFaces[0].update(this.posX - s, this.posY - s, this.posX - s, this.posY + s);
-            this.verticalFaces[1].update(this.posX + s, this.posY - s, this.posX + s, this.posY + s);
-        }
-
-        return this.verticalFaces;
     }
 }

--- a/src/main/java/tanks/bullet/Bullet.java
+++ b/src/main/java/tanks/bullet/Bullet.java
@@ -17,10 +17,7 @@ import tanks.network.event.*;
 import tanks.obstacle.Obstacle;
 import tanks.obstacle.ObstacleStackable;
 import tanks.tank.*;
-import tanks.tankson.ICopyable;
-import tanks.tankson.ITanksONEditable;
-import tanks.tankson.Property;
-import tanks.tankson.TanksONable;
+import tanks.tankson.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -1024,7 +1021,7 @@ public class Bullet extends Movable implements ICopyable<Bullet>, ITanksONEditab
 
 	public Ray getRay()
 	{
-		Ray r = new Ray(posX, posY, this.getAngleInDirection(this.posX + this.vX, this.posY + this.vY), this.bounces, tank);
+		Ray r = Ray.newRay(posX, posY, this.getAngleInDirection(this.posX + this.vX, this.posY + this.vY), this.bounces, tank);
 		r.size = this.size;
 		return r;
 	}
@@ -1058,7 +1055,7 @@ public class Bullet extends Movable implements ICopyable<Bullet>, ITanksONEditab
 			if (nearest != null && !this.destroy)
 			{
 				double a = this.getAngleInDirection(nearest.posX, nearest.posY);
-				Ray r = new Ray(this.posX, this.posY, a, 0, this.tank);
+				Ray r = Ray.newRay(this.posX, this.posY, a, 0, this.tank);
 
 				if (this instanceof BulletArc || this instanceof BulletAirStrike)
 				{
@@ -1775,7 +1772,13 @@ public class Bullet extends Movable implements ICopyable<Bullet>, ITanksONEditab
 	@Override
 	public boolean disableRayCollision()
 	{
-		return /*!bulletCollision()*/ true;		// temporary fix to avoid rays hitting a tank's own bullets
+		return !bulletCollision();
+	}
+
+	@Override
+	public boolean tankCollision()
+	{
+		return enableCollision && enableExternalCollisions;
 	}
 
 	@Override

--- a/src/main/java/tanks/bullet/BulletBlock.java
+++ b/src/main/java/tanks/bullet/BulletBlock.java
@@ -145,9 +145,9 @@ public class BulletBlock extends BulletArc
         if (ScreenGame.finishedQuick)
             return;
 
-        boolean found = Chunk.getIfPresent(x, y, true, tile -> !tile.canPlaceOn(o));
+        boolean canPlace = Chunk.getIfPresent(x, y, false, tile -> tile.canPlaceOn(o));
 
-        if (!found)
+        if (canPlace)
         {
             Game.addObstacle(o);
         }
@@ -157,7 +157,7 @@ public class BulletBlock extends BulletArc
             o.playDestroyAnimation(this.posX, this.posY, Game.tile_size);
         }
 
-        Game.eventsOut.add(new EventAddObstacleBullet(o, !found));
+        Game.eventsOut.add(new EventAddObstacleBullet(o, canPlace));
     }
 
     @Override

--- a/src/main/java/tanks/gui/Joystick.java
+++ b/src/main/java/tanks/gui/Joystick.java
@@ -4,6 +4,7 @@ import basewindow.InputPoint;
 import tanks.Drawing;
 import tanks.Game;
 import tanks.IDrawable;
+import tanks.Movable;
 import tanks.gui.screen.ScreenGame;
 import tanks.minigames.Arcade;
 import tanks.minigames.Minigame;
@@ -92,19 +93,7 @@ public class Joystick implements IDrawable
 
                     double dx = px - this.posX;
                     double dy = py - this.posY;
-
-                    double angle = 0;
-                    if (dx > 0)
-                        angle = Math.atan(dy / dx);
-                    else if (dx < 0)
-                        angle = Math.atan(dy / dx) + Math.PI;
-                    else
-                    {
-                        if (dy > 0)
-                            angle = Math.PI / 2;
-                        else if (dy < 0)
-                            angle = Math.PI * 3 / 2;
-                    }
+                    double angle = Movable.getPolarDirection(dx, dy);
 
                     this.inputAngle = (Math.PI * 2 + angle) % (Math.PI * 2);
 

--- a/src/main/java/tanks/gui/ScreenElement.java
+++ b/src/main/java/tanks/gui/ScreenElement.java
@@ -85,7 +85,7 @@ public abstract class ScreenElement
         {
             message = String.format(message, objects);
             int brightness = Level.isDark() ? 255 : 0;
-            this.styling = new TextWithStyling(message, brightness, brightness, brightness, 70 - Math.max(8, message.length()));
+            this.styling = new TextWithStyling(message, brightness, brightness, brightness, 80 - Math.max(8, message.length() * 2));
             this.styling.colorA = 128;
             this.duration = duration;
             this.previous = Panel.currentMessage != null;

--- a/src/main/java/tanks/gui/screen/ScreenTitle.java
+++ b/src/main/java/tanks/gui/screen/ScreenTitle.java
@@ -4,13 +4,8 @@ import tanks.*;
 import tanks.gui.Button;
 import tanks.item.ItemBullet;
 import tanks.minigames.Minigame;
-import tanks.obstacle.Face;
-import tanks.obstacle.ISolidObject;
 import tanks.obstacle.Obstacle;
 import tanks.tank.*;
-
-import java.util.Arrays;
-import java.util.Collections;
 
 import static basewindow.InputCodes.*;
 
@@ -21,15 +16,9 @@ public class ScreenTitle extends Screen implements ISeparateBackgroundScreen
 
 	public int chain;
 
-	public double lCenterX;
-	public double lCenterY;
+	public double lCenterX, lCenterY;
+	public double rCenterX, rCenterY;
 
-	public double rCenterX;
-	public double rCenterY;
-
-	public Face[] horizontalFaces;
-	public Face[] verticalFaces;
-	
 	protected int[] inputs = new int[11];
 	protected int inputCount = 0;
 
@@ -50,7 +39,7 @@ public class ScreenTitle extends Screen implements ISeparateBackgroundScreen
 		}
 	}
 	);
-	
+
 	Button options = new Button(this.rCenterX, this.rCenterY - this.objYSpace * 0.5, this.objWidth, this.objHeight, "Options", () ->
 	{
 		Game.silentCleanUp();
@@ -71,7 +60,7 @@ public class ScreenTitle extends Screen implements ISeparateBackgroundScreen
 		Game.screen = new ScreenAbout();
 	}
 	);
-	
+
 	Button play = new Button(this.rCenterX, this.rCenterY - this.objYSpace * 1.5, this.objWidth, this.objHeight, "Play!", () ->
 	{
 		Game.silentCleanUp();
@@ -104,7 +93,7 @@ public class ScreenTitle extends Screen implements ISeparateBackgroundScreen
 			}
 		}
 	}
-		);
+	);
 
 	Button languages = new Button(-1000, -1000, this.objHeight * 1.5, this.objHeight * 1.5, "", () ->
 	{
@@ -127,16 +116,8 @@ public class ScreenTitle extends Screen implements ISeparateBackgroundScreen
 
 		languages.imageSizeX = this.objHeight;
 		languages.imageSizeY = this.objHeight;
-
-		this.horizontalFaces = new Face[2];
-		this.horizontalFaces[0] = new Face(null, 0, 0, Game.currentSizeX * Game.tile_size, 0, true, false, true, true);
-		this.horizontalFaces[1] = new Face(null, 0, Game.currentSizeY * Game.tile_size, Game.currentSizeX * Game.tile_size, Game.currentSizeY * Game.tile_size, true, true,true, true);
-
-		this.verticalFaces = new Face[2];
-		this.verticalFaces[0] = new Face(null, 0, 0,0, Game.currentSizeY * Game.tile_size, false, false,true, true);
-		this.verticalFaces[1] = new Face(null, Game.currentSizeX * Game.tile_size, 0, Game.currentSizeX * Game.tile_size, Game.currentSizeY * Game.tile_size, false, true, true, true);
 	}
-	
+
 	@Override
 	public void update()
 	{
@@ -164,12 +145,12 @@ public class ScreenTitle extends Screen implements ISeparateBackgroundScreen
 			about.update();
 
 			this.music = "menu_1.ogg";
-			
+
 			for (Integer i: Game.game.window.validPressedKeys)
 			{
 				this.inputs[inputCount] = i;
 				inputCount = (inputCount + 1) % inputs.length;
-				
+
 				if (i == KEY_ENTER)
 				{
 					int[] inputs = new int[]{KEY_UP, KEY_UP, KEY_DOWN, KEY_DOWN, KEY_LEFT, KEY_RIGHT, KEY_LEFT, KEY_RIGHT, KEY_B, KEY_A, KEY_ENTER};
@@ -211,73 +192,6 @@ public class ScreenTitle extends Screen implements ISeparateBackgroundScreen
 		{
 			this.logo.hidden = false;
 			this.logo.invulnerable = false;
-		}
-
-		Game.horizontalFaces.clear();
-		Game.verticalFaces.clear();
-
-		this.horizontalFaces[0].update(0, 0, Game.currentSizeX * Game.tile_size, 0);
-		this.horizontalFaces[1].update(0, Game.currentSizeY * Game.tile_size, Game.currentSizeX * Game.tile_size, Game.currentSizeY * Game.tile_size);
-		Game.horizontalFaces.add(this.horizontalFaces[0]);
-		Game.horizontalFaces.add(this.horizontalFaces[1]);
-
-		this.verticalFaces[0].update(0, 0, 0, Game.currentSizeY * Game.tile_size);
-		this.verticalFaces[1].update(Game.currentSizeX * Game.tile_size, 0, Game.currentSizeX * Game.tile_size, Game.currentSizeY * Game.tile_size);
-		Game.verticalFaces.add(this.verticalFaces[0]);
-		Game.verticalFaces.add(this.verticalFaces[1]);
-
-		for (Movable m : Game.movables)
-		{
-			if (Double.isNaN(m.posX) || Double.isNaN(m.posY))
-			{
-				throw new RuntimeException("Movable with NaN position: " + m.toString() + " " + m.lastPosX + " " + m.lastPosY);
-			}
-
-			if (m instanceof ISolidObject && !(m instanceof Tank && !(((Tank) m).currentlyTargetable || ((Tank) m).invulnerabilityTimer > 0)))
-			{
-				Game.horizontalFaces.addAll(Arrays.asList(((ISolidObject) m).getHorizontalFaces()));
-
-				Game.verticalFaces.addAll(Arrays.asList(((ISolidObject) m).getVerticalFaces()));
-			}
-		}
-
-		for (Obstacle o : Game.obstacles)
-		{
-			Face[] faces = o.getHorizontalFaces();
-			boolean[] valid = o.getValidHorizontalFaces(true);
-			for (int i = 0; i < faces.length; i++)
-			{
-				if (valid[i])
-					Game.horizontalFaces.add(faces[i]);
-			}
-
-			faces = o.getVerticalFaces();
-			valid = o.getValidVerticalFaces(true);
-			for (int i = 0; i < faces.length; i++)
-			{
-				if (valid[i])
-					Game.verticalFaces.add(faces[i]);
-			}
-		}
-
-		try
-		{
-			Collections.sort(Game.horizontalFaces);
-		}
-		catch (Exception e)
-		{
-			System.out.println(Game.horizontalFaces);
-			Game.exitToCrash(e);
-		}
-
-		try
-		{
-			Collections.sort(Game.verticalFaces);
-		}
-		catch (Exception e)
-		{
-			System.out.println(Game.verticalFaces);
-			Game.exitToCrash(e);
 		}
 
 		Obstacle.draw_size = Game.tile_size;
@@ -483,6 +397,9 @@ public class ScreenTitle extends Screen implements ISeparateBackgroundScreen
 		if (Game.screen == this)
 			this.drawDefaultBackground();
 
+		if (Chunk.debug)
+			Chunk.drawDebugStuff();
+
 		this.drawWithoutBackground();
 	}
 
@@ -490,9 +407,7 @@ public class ScreenTitle extends Screen implements ISeparateBackgroundScreen
 	public void drawPostMouse()
 	{
 		if (!this.controlPlayer && (Game.game.window.pressedKeys.contains(KEY_LEFT_SHIFT) || Game.game.window.pressedKeys.contains(KEY_RIGHT_SHIFT)) && Drawing.drawing.interfaceScaleZoom == 1)
-		{
 			this.logo.draw();
-		}
 	}
 
 	@Override

--- a/src/main/java/tanks/obstacle/Face.java
+++ b/src/main/java/tanks/obstacle/Face.java
@@ -1,16 +1,11 @@
 package tanks.obstacle;
 
 import tanks.Direction;
+import tanks.tank.Tank;
 
 public class Face implements Comparable<Face>
 {
-    public double startX;
-    public double startY;
-    public double endX;
-    public double endY;
-
-    public boolean horizontal;
-    public boolean positiveCollision;
+    public double startX, startY, endX, endY;
 
     /**
      * The <code>startX</code> of a length 1 face, where index <code>i</code> of the array corresponds to
@@ -39,32 +34,6 @@ public class Face implements Comparable<Face>
     public final Direction direction;
     public boolean solidTank, solidBullet;
     public boolean valid = true;
-    public boolean lastValid;
-
-    @Deprecated
-    public Face(ISolidObject o, double x1, double y1, double x2, double y2, boolean horizontal, boolean positiveCollision, boolean tank, boolean bullet)
-    {
-        this.owner = o;
-        this.startX = x1;
-        this.startY = y1;
-        this.endX = x2;
-        this.endY = y2;
-        this.horizontal = horizontal;
-        this.positiveCollision = positiveCollision;
-
-        this.solidTank = tank;
-        this.solidBullet = bullet;
-        if (horizontal)
-            this.direction = positiveCollision ? Direction.up : Direction.down;
-        else
-            this.direction = positiveCollision ? Direction.right : Direction.left;
-    }
-
-    public Face(ISolidObject o, double x1, double y1, double x2, double y2, Direction direction, boolean tank, boolean bullet)
-    {
-        this(o, direction, tank, bullet);
-        update(x1, y1, x2, y2, true, tank, bullet);
-    }
 
     public Face(ISolidObject o, Direction direction, boolean tank, boolean bullet)
     {
@@ -72,6 +41,12 @@ public class Face implements Comparable<Face>
         this.direction = direction;
         this.solidTank = tank;
         this.solidBullet = bullet;
+    }
+
+    public Face(ISolidObject o, double x1, double y1, double x2, double y2, Direction direction, boolean tank, boolean bullet)
+    {
+        this(o, direction, tank, bullet);
+        update(x1, y1, x2, y2, true, tank, bullet);
     }
 
     public int compareTo(Face f)
@@ -95,7 +70,6 @@ public class Face implements Comparable<Face>
         this.startY = y1;
         this.endX = x2;
         this.endY = y2;
-        this.lastValid = this.valid;
         this.valid = valid;
         this.solidTank = tank;
         this.solidBullet = bullet;
@@ -126,9 +100,10 @@ public class Face implements Comparable<Face>
 
     public String toString()
     {
-        if (this.horizontal)
-            return this.startX + "-" + this.endX + " " + this.startY;
+        String ownerName = this.owner instanceof Obstacle ? ((Obstacle) this.owner).name : this.owner instanceof Tank ? ((Tank) this.owner).name : this.owner != null ? this.owner.getClass().getSimpleName() : "null";
+        if (this.direction.isNonZeroY())
+            return String.format("%.1f-%.1f %.1f  %s", this.startX, this.endX, this.startY, ownerName);
         else
-            return this.startX + " " + this.startY + "-" + this.endY;
+            return String.format("%.1f %.1f-%.1f  %s", this.startX, this.startY, this.endY, ownerName);
     }
 }

--- a/src/main/java/tanks/obstacle/ISolidObject.java
+++ b/src/main/java/tanks/obstacle/ISolidObject.java
@@ -2,11 +2,7 @@ package tanks.obstacle;
 
 public interface ISolidObject
 {
-	default boolean disableRayCollision() {return false;}
-
-	Face[] getHorizontalFaces();
-
-	Face[] getVerticalFaces();
+	default boolean disableRayCollision() { return false; }
 
 	Face[] getFaces();
 

--- a/src/main/java/tanks/obstacle/ObstacleBeatBlock.java
+++ b/src/main/java/tanks/obstacle/ObstacleBeatBlock.java
@@ -72,12 +72,11 @@ public class ObstacleBeatBlock extends ObstacleStackable
                 this.postOverride();
 
             this.firstUpdate = false;
-            this.verticalFaces = null;
-            this.horizontalFaces = null;
             this.allowBounce = false;
             this.shouldClip = true;
 
             this.lastOn = this.tankCollision;
+            refreshHitboxes();
         }
         else
         {

--- a/src/main/java/tanks/obstacle/ObstacleBoostPanel.java
+++ b/src/main/java/tanks/obstacle/ObstacleBoostPanel.java
@@ -160,18 +160,4 @@ public class ObstacleBoostPanel extends Obstacle
         return 10;
     }
 
-    @Override
-    public Effect getCompanionEffect()
-    {
-        if (Game.glowEnabled && brightness > 0)
-        {
-            glow.posX = this.posX;
-            glow.posY = this.posY;
-            glow.size = this.brightness;
-
-            return glow;
-        }
-
-        return null;
-    }
 }

--- a/src/main/java/tanks/obstacle/ObstacleHole.java
+++ b/src/main/java/tanks/obstacle/ObstacleHole.java
@@ -24,6 +24,7 @@ public class ObstacleHole extends Obstacle
 		this.colorA = 127;
 
 		this.description = "A hole which only bullets can pass over";
+		this.type = ObstacleType.ground;
 
 		this.tileRenderer = ShaderHole.class;
 	}

--- a/src/main/java/tanks/obstacle/ObstacleStackable.java
+++ b/src/main/java/tanks/obstacle/ObstacleStackable.java
@@ -155,22 +155,6 @@ public class ObstacleStackable extends Obstacle
     }
 
     @Override
-    public boolean[] getValidHorizontalFaces(boolean unbreakable)
-    {
-        this.validFaces[0] = (!this.hasNeighbor(0, -1, unbreakable) || this.startHeight > 1) && !(!this.tankCollision && !this.bulletCollision);
-        this.validFaces[1] = (!this.hasNeighbor(0, 1, unbreakable) || this.startHeight > 1) && !(!this.tankCollision && !this.bulletCollision);
-        return this.validFaces;
-    }
-
-    @Override
-    public boolean[] getValidVerticalFaces(boolean unbreakable)
-    {
-        this.validFaces[0] = (!this.hasNeighbor(-1, 0, unbreakable) || this.startHeight > 1) && !(!this.tankCollision && !this.bulletCollision);
-        this.validFaces[1] = (!this.hasNeighbor(1, 0, unbreakable) || this.startHeight > 1) && !(!this.tankCollision && !this.bulletCollision);
-        return this.validFaces;
-    }
-
-    @Override
     public double getTileHeight()
     {
         if (Obstacle.draw_size < Game.tile_size || this.startHeight > 1)

--- a/src/main/java/tanks/rendering/TerrainRenderer.java
+++ b/src/main/java/tanks/rendering/TerrainRenderer.java
@@ -752,11 +752,11 @@ public class TerrainRenderer
         double s = Obstacle.draw_size;
         Obstacle.draw_size = Game.tile_size;
 
-        if (stagedCount == 0)
-            totalObjectsCount = Game.currentSizeX * Game.currentSizeY + Game.obstacles.size();
-
         for (Obstacle o : Game.obstacles)
             o.postOverride();
+
+        if (stagedCount == 0)
+            totalObjectsCount = Game.currentSizeX * Game.currentSizeY + Game.obstacles.size();
 
         drawBorders();
 
@@ -812,6 +812,8 @@ public class TerrainRenderer
         if (o.batchDraw && !o.removed)
             o.draw();
     }
+
+
 
     public static class RegionRenderer
     {

--- a/src/main/java/tanks/tank/Ray.java
+++ b/src/main/java/tanks/tank/Ray.java
@@ -1,30 +1,37 @@
 package tanks.tank;
 
-import tanks.Effect;
-import tanks.Game;
-import tanks.Movable;
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import tanks.*;
+import tanks.bullet.Bullet;
 import tanks.gui.screen.ScreenGame;
 import tanks.obstacle.Face;
+import tanks.obstacle.ISolidObject;
 import tanks.obstacle.Obstacle;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 
 public class Ray
 {
 	public static double min_trace_size = 5;
 
+	public static int chunksAdded;
+	/** Caches the chunks to avoid creating new temp objects */
+	public static Chunk[] chunkCache = new Chunk[40];
+	/** Caches the ray to avoid creating new temp objects */
+	public static Ray cacheRay = new Ray();
+
 	public double size = 10;
 	public double tankHitSizeMul = 1;
 
-	public int bounces;
-	public int bouncyBounces = 100;
-	public double posX;
-	public double posY;
-	public double vX;
-	public double vY;
+	public int bounces, bouncyBounces = 100;
+	public double posX, posY, vX, vY, angle;
+	public double startX, startY;
+
+	public int maxChunkCheck = 100;
 
 	public boolean enableBounciness = true;
+	public boolean asBullet = true;
+	public boolean ignoreTanks = false, ignoreBullets = true;
 	public boolean ignoreDestructible = false;
 	public boolean ignoreShootThrough = false;
 
@@ -32,122 +39,182 @@ public class Ray
 	public boolean dotted = false;
 
 	public double speed = 10;
+	public double range;
 
 	public double age = 0;
 	public int traceAge;
 
-	public Tank tank;
-	public Tank targetTank;
+	public Tank tank, targetTank;
+	public double targetTankSizeMul = 0;
 
-	public ArrayList<Double> bounceX = new ArrayList<>();
-	public ArrayList<Double> bounceY = new ArrayList<>();
+	public DoubleArrayList bounceX = new DoubleArrayList();
+	public DoubleArrayList bounceY = new DoubleArrayList();
 
-	public double targetX;
-	public double targetY;
+	public double targetX, targetY;
+	public boolean acquiredTarget = false;
 
-	public double range = -1;
-
-	public static long count = 0;
-
-	public Ray(double x, double y, double angle, int bounces, Tank tank)
+	/** Should be consumed immediately via getTarget or getDist. Otherwise, use {@linkplain #copy()}  */
+	public static Ray newRay(double x, double y, double angle, int bounces, Tank tank)
 	{
-		count++;
-		this.vX = speed * Math.cos(angle);
-		this.vY = speed * Math.sin(angle);
-
-		this.posX = x;
-		this.posY = y;
-		this.bounces = bounces;
-
-		this.tank = tank;
+		return newRay(x, y, angle, bounces, tank, 10);
 	}
 
-	public Ray(double x, double y, double angle, int bounces, Tank tank, double speed)
+	/** Should be consumed immediately via getTarget or getDist. Otherwise, use {@linkplain #copy()}  */
+	public static Ray newRay(double x, double y, double angle, int bounces, Tank tank, double speed)
 	{
-		count++;
+		return cacheRay.set(x, y, angle, bounces, tank, speed);
+	}
+
+	/** Creates another ray with the properties of the last ray.<br>
+	 * To set custom properties on your ray copy:
+	 * <blockquote><pre>
+	 *     Ray copy = Ray.newRay(params).copy()
+	 * </pre></blockquote>
+	 * */
+	public Ray copy()
+	{
+		return new Ray().set(posX, posY, angle, bounces, tank, speed);
+	}
+
+	private Ray() {}
+
+	public Ray set(double x, double y, double angle, int bounces, Tank tank, double speed)
+	{
 		this.vX = speed * Math.cos(angle);
 		this.vY = speed * Math.sin(angle);
+		this.angle = angle;
 
-		this.posX = x;
-		this.posY = y;
+		this.posX = this.startX = x;
+		this.posY = this.startY = y;
 		this.bounces = bounces;
+		this.bouncyBounces = 100;
+		setSize(10).setMaxChunks(12);
 
-		this.tank = tank;
+		this.trace = Game.traceAllRays;
+		this.dotted = false;
+		this.enableBounciness = true;
+		this.ignoreTanks = false;
+		this.ignoreBullets = true;
+		this.asBullet = true;
+		this.ignoreDestructible = false;
+		this.ignoreShootThrough = false;
+
+		this.age = 0;
+		this.range = 0;
+		this.tankHitSizeMul = 1;
+		this.acquiredTarget = false;
+		this.tank = tank.getBottomLevelPossessing();
+
+		this.bounceX.clear();
+		this.bounceY.clear();
+
+		return this;
 	}
 
 	public Movable getTarget(double mul, Tank targetTank)
 	{
 		this.targetTank = targetTank;
-		this.targetTank.size *= mul;
-
-		for (Face f: this.targetTank.getHorizontalFaces())
-			Game.horizontalFaces.remove(f);
-
-		for (Face f: this.targetTank.getVerticalFaces())
-			Game.verticalFaces.remove(f);
-
-		for (Face f: this.targetTank.getHorizontalFaces())
-			addFace(f);
-
-		for (Face f: this.targetTank.getVerticalFaces())
-			addFace(f);
-
-		Movable m = this.getTarget();
-
-		for (Face f: this.targetTank.getHorizontalFaces())
-			Game.horizontalFaces.remove(f);
-
-		for (Face f: this.targetTank.getVerticalFaces())
-			Game.verticalFaces.remove(f);
-
-		this.targetTank.size /= mul;
-
-		for (Face f: this.targetTank.getHorizontalFaces())
-			addFace(f);
-
-		for (Face f: this.targetTank.getVerticalFaces())
-			addFace(f);
-
-		return m;
+		this.targetTankSizeMul = mul;
+		return this.getTarget();
 	}
 
-	public void addFace(Face f)
+	public boolean isInSight(Movable target)
 	{
-		if (f.horizontal)
-		{
-			int i = Collections.binarySearch(Game.horizontalFaces, f);
-			if (i < 0)
-				i = -i - 1;
-
-			Game.horizontalFaces.add(i, f);
-		}
-		else
-		{
-			int i = Collections.binarySearch(Game.verticalFaces, f);
-			if (i < 0)
-				i = -i - 1;
-
-			Game.verticalFaces.add(i, f);
-		}
+		return setVelocity(target.posX - this.posX, target.posY - this.posY).getTarget() == target;
 	}
+
+	public Ray setVelocity(double vX, double vY)
+	{
+		this.vX = vX;
+		this.vY = vY;
+		this.angle = Movable.getPolarDirection(vX, vY);
+		return this;
+	}
+
+	public Ray setShootThrough(boolean shootThrough)
+	{
+		this.ignoreShootThrough = shootThrough;
+		return this;
+	}
+
+	public Ray setExplosive(boolean explosive)
+	{
+		this.ignoreDestructible = explosive;
+		return this;
+	}
+
+	public Ray setBouncyBounces(int bouncyBounces)
+	{
+		this.bouncyBounces = bouncyBounces;
+		return this;
+	}
+
+	public Ray setAsBullet(boolean testBulletCollision)
+	{
+		this.asBullet = testBulletCollision;
+		return this;
+	}
+
+	public Ray setMaxChunks(int maxChunks)
+	{
+		this.maxChunkCheck = maxChunks;
+		return this;
+	}
+
+	public Ray setTrace(boolean trace, boolean dotted)
+	{
+		this.trace = trace;
+		this.dotted = dotted;
+		return this;
+	}
+
+	@SuppressWarnings("unused")
+	public Ray setMaxDistance(double distance)
+	{
+		setMaxChunks((int) (distance / Game.tile_size / Chunk.chunkSize + 1));
+		return this;
+	}
+
+	public Ray setRange(double range)
+	{
+		this.range = range;
+		return this;
+	}
+
+	public Ray setSize(double size)
+	{
+		this.size = size;
+		return this;
+	}
+
+	public Ray moveOut(double amount)
+	{
+		this.posX += this.vX * amount;
+		this.posY += this.vY * amount;
+		return this;
+	}
+
+	public static final Result result = new Result();
 
 	public Movable getTarget()
 	{
-		this.bounceX.add(0, this.posX);
-		this.bounceY.add(0, this.posY);
-
 		double remainder = 0;
+		acquiredTarget = true;
 
-		if (isInsideObstacle(this.posX - size / 2, this.posY - size / 2) ||
-				isInsideObstacle(this.posX + size / 2, this.posY - size / 2) ||
-				isInsideObstacle(this.posX + size / 2, this.posY + size / 2) ||
-				isInsideObstacle(this.posX - size / 2, this.posY + size / 2))
+		if (testInsideObstacle(posX, posY))
 			return null;
 
-		for (Movable m: Game.movables)
+		if (!ignoreTanks)
 		{
-			if (m instanceof Tank && m != this.tank)
+			Chunk c = Chunk.getChunk(posX, posY);
+			if (c == null)
+				return null;
+
+			for (Movable m : c.movables)
 			{
+				if (!(m instanceof Tank) || m == this.tank)
+					continue;
+
 				Tank t = (Tank) m;
 				if (this.posX + this.size / 2 >= t.posX - t.size / 2 &&
 						this.posX - this.size / 2 <= t.posX + t.size / 2 &&
@@ -161,341 +228,390 @@ public class Ray
 
 		while (this.bounces >= 0 && this.bouncyBounces >= 0)
 		{
-			double t = Double.MAX_VALUE;
-			double collisionX = -1;
-			double collisionY = -1;
-			Face collisionFace = null;
+			Chunk current = Chunk.getChunk(posX, posY);
+			if (current == null)
+				return null;
 
-			int skipped = 0;
-			int passed = 0;
+			checkFaceList(current, firstBounce);
 
-			if (vX > 0)
-			{
-				int s = Collections.binarySearch(Game.verticalFaces, new Face(null, this.posX + size / 2 * tankHitSizeMul, 0, this.posX + size / 2 * tankHitSizeMul, 0, false, false, false, false));
-				if (s < 0)
-					s = -s - 1;
-
-				for (int i = s; i < Game.verticalFaces.size(); i++)
-				{
-					double size = this.size;
-
-					Face f = Game.verticalFaces.get(i);
-					if (f.owner instanceof Movable)
-						size *= tankHitSizeMul;
-
-					boolean passThrough = false;
-					if (f.owner instanceof Obstacle)
-					{
-						Obstacle o = (Obstacle) f.owner;
-
-						if (!o.bouncy)
-							passThrough = (this.ignoreDestructible && o.destructible) || (this.ignoreShootThrough && o.shouldShootThrough);
-					}
-
-					if (f.startX < this.posX + size / 2 || !f.solidBullet || !f.positiveCollision || (f.owner == this.tank && firstBounce) || passThrough)
-					{
-						//Game.effects.add(Effect.createNewEffect( (f.startX + f.endX) / 2, (f.startY + f.endY) / 2, 60, Effect.EffectType.laser));
-						skipped++;
-						continue;
-					}
-
-					//Game.effects.add(Effect.createNewEffect( (f.startX + f.endX) / 2, (f.startY + f.endY) / 2, 60, Effect.EffectType.healing));
-					passed++;
-					double y = (f.startX - size / 2 - this.posX) * vY / vX + this.posY;
-					if (y >= f.startY - size / 2 && y <= f.endY + size / 2)
-					{
-						t = (f.startX - size / 2 - this.posX) / vX;
-						collisionX = f.startX - size / 2;
-						collisionY = y;
-						collisionFace = f;
-						break;
-					}
-
-					if (y < 0 || y > Game.currentSizeY * Game.tile_size)
-						break;
-				}
-			}
-			else if (vX < 0)
-			{
-				int s = Collections.binarySearch(Game.verticalFaces, new Face(null, this.posX - size / 2 * tankHitSizeMul, 0, this.posX - size / 2 * tankHitSizeMul, 0, false, false, false, false));
-				if (s < 0)
-					s = -s - 2;
-
-				for (int i = s; i >= 0; i--)
-				{
-					Face f = Game.verticalFaces.get(i);
-
-					double size = this.size;
-
-					if (f.owner instanceof Movable)
-						size *= tankHitSizeMul;
-
-					boolean passThrough = false;
-					if (f.owner instanceof Obstacle)
-					{
-						Obstacle o = (Obstacle) f.owner;
-
-						if (!o.bouncy)
-							passThrough = (this.ignoreDestructible && o.destructible) || (this.ignoreShootThrough && o.shouldShootThrough);
-					}
-
-					if (f.startX > this.posX - size / 2 || !f.solidBullet || f.positiveCollision || (f.owner == this.tank && firstBounce) || passThrough)
-					{
-						//Game.effects.add(Effect.createNewEffect( (f.startX + f.endX) / 2, (f.startY + f.endY) / 2, 60, Effect.EffectType.laser));
-						skipped++;
-						continue;
-					}
-
-					//Game.effects.add(Effect.createNewEffect( (f.startX + f.endX) / 2, (f.startY + f.endY) / 2, 60, Effect.EffectType.healing));
-					passed++;
-					double y = (f.startX + size / 2 - this.posX) * vY / vX + this.posY;
-					if (y >= f.startY - size / 2 && y <= f.endY + size / 2)
-					{
-						t = (f.startX + size / 2 - this.posX) / vX;
-						collisionX = f.startX + size / 2;
-						collisionY = y;
-						collisionFace = f;
-						break;
-					}
-
-					if (y < 0 || y > Game.currentSizeY * Game.tile_size)
-						break;
-				}
-			}
-
-			boolean corner = false;
-			if (vY > 0)
-			{
-				int s = Collections.binarySearch(Game.horizontalFaces, new Face(null, 0, this.posY + size / 2 * tankHitSizeMul, 0, this.posY + size / 2 * tankHitSizeMul, true, false, false, false));
-				if (s < 0)
-					s = -s - 1;
-
-				for (int i = s; i < Game.horizontalFaces.size(); i++)
-				{
-					Face f = Game.horizontalFaces.get(i);
-
-					double size = this.size;
-
-					if (f.owner instanceof Movable)
-						size *= tankHitSizeMul;
-
-					boolean passThrough = false;
-					if (f.owner instanceof Obstacle)
-					{
-						Obstacle o = (Obstacle) f.owner;
-
-						if (!o.bouncy)
-							passThrough = (this.ignoreDestructible && o.destructible) || (this.ignoreShootThrough && o.shouldShootThrough);
-					}
-
-					if (f.startY < this.posY + size / 2 || !f.solidBullet || !f.positiveCollision || (f.owner == this.tank && firstBounce) || passThrough)
-					{
-						//Game.effects.add(Effect.createNewEffect( (f.startX + f.endX) / 2, (f.startY + f.endY) / 2, 60, Effect.EffectType.laser));
-						skipped++;
-						continue;
-					}
-
-					//Game.effects.add(Effect.createNewEffect( (f.startX + f.endX) / 2, (f.startY + f.endY) / 2, 60, Effect.EffectType.healing));
-					passed++;
-					double x = (f.startY - size / 2 - this.posY) * vX / vY + this.posX;
-					if (x >= f.startX - size / 2 && x <= f.endX + size / 2)
-					{
-						double t1 = (f.startY - size / 2 - this.posY) / vY;
-
-						if (t1 == t)
-							corner = true;
-						else if (t1 < t)
-						{
-							collisionX = x;
-							collisionY = f.startY - size / 2;
-							collisionFace = f;
-							t = t1;
-						}
-
-						break;
-					}
-
-					if (x < 0 || x > Game.currentSizeX * Game.tile_size)
-						break;
-				}
-			}
-			else if (vY < 0)
-			{
-				int s = Collections.binarySearch(Game.horizontalFaces, new Face(null, 0, this.posY - size / 2 * tankHitSizeMul, 0, this.posY - size / 2 * tankHitSizeMul, true, false, false, false));
-				if (s < 0)
-					s = -s - 2;
-
-				for (int i = s; i >= 0; i--)
-				{
-					Face f = Game.horizontalFaces.get(i);
-
-					double size = this.size;
-
-					if (f.owner instanceof Movable)
-						size *= tankHitSizeMul;
-
-					boolean passThrough = false;
-					if (f.owner instanceof Obstacle)
-					{
-						Obstacle o = (Obstacle) f.owner;
-
-						if (!o.bouncy)
-							passThrough = (this.ignoreDestructible && o.destructible) || (this.ignoreShootThrough && o.shouldShootThrough);
-					}
-
-					if (f.startY > this.posY - size / 2 || !f.solidBullet || f.positiveCollision || (f.owner == this.tank && firstBounce) || passThrough)
-					{
-						//Game.effects.add(Effect.createNewEffect( (f.startX + f.endX) / 2, (f.startY + f.endY) / 2, 60, Effect.EffectType.laser));
-						skipped++;
-						continue;
-					}
-
-					//Game.effects.add(Effect.createNewEffect( (f.startX + f.endX) / 2, (f.startY + f.endY) / 2, 60, Effect.EffectType.healing));
-					passed++;
-					double x = (f.startY + size / 2 - this.posY) * vX / vY + this.posX;
-					if (x >= f.startX - size / 2 && x <= f.endX + size / 2)
-					{
-						double t1 = (f.startY + size / 2 - this.posY) / vY;
-
-						if (t1 == t)
-							corner = true;
-						else if (t1 < t)
-						{
-							collisionX = x;
-							collisionY = f.startY + size / 2;
-							collisionFace = f;
-							t = t1;
-						}
-						break;
-					}
-
-					if (x < 0 || x > Game.currentSizeX * Game.tile_size)
-						break;
-				}
-			}
-
-//			System.out.println(skipped + " " + passed + " " + vX + " " + vY);
-
-			this.age += t;
+			this.age += result.t;
 
 			firstBounce = false;
 
-			if (collisionFace != null)
-			{
-				double dx = collisionX - posX;
-				double dy = collisionY - posY;
-
-				if (this.range > 0)
-				{
-					double dist = Math.sqrt(dx * dx + dy * dy);
-					if (this.range < dist)
-					{
-						collisionX = posX + dx * range / dist;
-						collisionY = posY + dy * range / dist;
-						dx = collisionX - posX;
-						dy = collisionY - posY;
-						this.bounces = -1;
-					}
-					else
-						this.range -= dist;
-				}
-
-				if (trace)
-				{
-					double steps = (Math.sqrt((Math.pow(dx, 2) + Math.pow(dy, 2)) / (1 + Math.pow(this.vX, 2) + Math.pow(this.vY, 2))) / Math.max(this.size, 2) * 10 + 1);
-
-					if (dotted)
-						steps /= 2;
-
-					double s;
-					for (s = remainder; s <= steps; s++)
-					{
-						double x = posX + dx * s / steps;
-						double y = posY + dy * s / steps;
-
-						this.traceAge++;
-
-						double frac = 1 / (1 + this.traceAge / 100.0);
-						double z = this.tank.size / 2 + this.tank.turretSize / 2 * frac + (Game.tile_size / 4) * (1 - frac);
-						if (Game.screen instanceof ScreenGame && !ScreenGame.finished)
-						{
-							Effect e = Effect.createNewEffect(x, y, z, Effect.EffectType.ray);
-							e.size = Math.max(this.size, min_trace_size);
-							Game.effects.add(e);
-						}
-					}
-
-					remainder = s - steps;
-				}
-
-				this.posX = collisionX;
-				this.posY = collisionY;
-
-				if (collisionFace.owner instanceof Movable)
-				{
-					this.targetX = collisionX;
-					this.targetY = collisionY;
-					bounceX.add(collisionX);
-					bounceY.add(collisionY);
-
-					return (Movable) collisionFace.owner;
-				}
-				else if (collisionFace.owner instanceof Obstacle && ((Obstacle) collisionFace.owner).bouncy)
-					this.bouncyBounces--;
-				else if (collisionFace.owner instanceof Obstacle && !((Obstacle) collisionFace.owner).allowBounce)
-					this.bounces = -1;
-				else
-					this.bounces--;
-
-				bounceX.add(collisionX);
-				bounceY.add(collisionY);
-
-				if (this.bounces >= 0)
-				{
-					if (corner)
-					{
-						this.vX = -this.vX;
-						this.vY = -this.vY;
-					}
-					else if (collisionFace.horizontal)
-						this.vY = -this.vY;
-					else
-						this.vX = -this.vX;
-				}
-			}
-			else
+			if (result.collisionFace == null)
 				return null;
+
+			double dx = result.collisionX - posX, dy = result.collisionY - posY;
+
+			if (this.range > 0)
+			{
+				double dist = Math.sqrt(dx * dx + dy * dy);
+				if (this.range < dist)
+				{
+					result.collisionX = posX + dx * range / dist;
+					result.collisionY = posY + dy * range / dist;
+					dx = result.collisionX - posX;
+					dy = result.collisionY - posY;
+					this.bounces = -1;
+				}
+				else
+					this.range -= dist;
+			}
+
+			if (trace && ScreenGame.isUpdatingGame())
+			{
+				double steps = (Math.sqrt((Math.pow(dx, 2) + Math.pow(dy, 2)) / (1 + Math.pow(this.vX, 2) + Math.pow(this.vY, 2))) / Math.max(this.size, 2) * 10 + 1);
+
+				if (dotted)
+					steps /= 2;
+
+				double s;
+				for (s = remainder; s <= steps; s++)
+				{
+					double x = posX + dx * s / steps;
+					double y = posY + dy * s / steps;
+
+					this.traceAge++;
+
+					double frac = 1 / (1 + this.traceAge / 100.0);
+					double z = this.tank.size / 2 + this.tank.turretSize / 2 * frac + (Game.tile_size / 4) * (1 - frac);
+					if (Game.screen instanceof ScreenGame && !ScreenGame.finished)
+					{
+						Game.effects.add(Effect.createNewEffect(x, y, z, Effect.EffectType.ray)
+								.setSize(Math.max(this.size, min_trace_size)));
+					}
+				}
+
+				remainder = s - steps;
+			}
+
+			this.posX = result.collisionX;
+			this.posY = result.collisionY;
+
+			if (Chunk.debug && trace)
+			{
+				Game.effects.add(Effect.createNewEffect(posX, posY, 50, Effect.EffectType.piece)
+						.setColor(0, 150, 0).setGlowEnabled(false));
+				Game.effects.add(Effect.createNewEffect(result.collisionFace.startX, result.collisionFace.startY, 50, Effect.EffectType.piece)
+						.setColor(255, 128, 0).setGlowEnabled(false));
+				Game.effects.add(Effect.createNewEffect(result.collisionFace.endX, result.collisionFace.endY, 50, Effect.EffectType.piece)
+						.setColor(255, 128, 0).setGlowEnabled(false));
+			}
+
+			ISolidObject obj = result.collisionFace.owner;
+			if (obj instanceof Movable)
+			{
+				this.targetX = result.collisionX;
+				this.targetY = result.collisionY;
+				bounceX.add(result.collisionX);
+				bounceY.add(result.collisionY);
+
+				return (Movable) obj;
+			}
+
+			if (obj instanceof Obstacle && ((Obstacle) obj).bouncy)
+				this.bouncyBounces--;
+			else if (obj instanceof Obstacle && !((Obstacle) obj).allowBounce)
+				this.bounces = -1;
+			else
+				this.bounces--;
+
+			bounceX.add(result.collisionX);
+			bounceY.add(result.collisionY);
+
+			if (this.bounces >= 0)
+			{
+				if (result.corner)
+				{
+					this.vX = -this.vX;
+					this.vY = -this.vY;
+				}
+				else if (!result.collisionFace.direction.isNonZeroX())
+					this.vY = -this.vY;
+				else
+					this.vX = -this.vX;
+
+				this.angle = Movable.getPolarDirection(this.vX, this.vY);
+			}
 		}
 
 		return null;
 	}
 
-	public double getDist()
+	public void checkFaceList(Chunk current, boolean firstBounce)
 	{
-		if (this.bounceX.isEmpty())
-			this.getTarget();
+		if (current == null)
+			return;
 
-		double dist = 0;
-		for (int i = 0; i < this.bounceX.size() - 1; i++)
+		int totalChunksChecked = 0;
+
+		chunkCheck:
+		for (int chunksChecked = 0; chunksChecked < maxChunkCheck; chunksChecked++)
 		{
-			dist += Math.sqrt(Math.pow(this.bounceX.get(i + 1) - this.bounceX.get(i), 2) + Math.pow(this.bounceY.get(i + 1) - this.bounceY.get(i), 2));
+			double moveXBase = Chunk.chunkSize * Game.tile_size * Math.cos(angle);
+			double moveYBase = Chunk.chunkSize * Game.tile_size * Math.sin(angle);
+			double moveX = moveXBase * chunksChecked, moveXPrev = moveXBase * Math.max(0, chunksChecked - 1);
+			double moveY = moveYBase * chunksChecked, moveYPrev = moveYBase * Math.max(0, chunksChecked - 1);
+
+			chunksAdded = 0;
+
+			// move forward one chunk in the ray's direction
+			Chunk mid = chunksChecked > 0 ? Chunk.getChunk(posX + moveX, posY + moveY) : null;
+			// add current chunk and chunk in front
+			addChunk(current, mid);
+
+			// if the ray moved diagonally, add the chunks on the sides
+			if (mid == null || current.manhattanDist(mid) > 1)
+			{
+				addChunk(current, Chunk.getChunk(posX + moveXPrev, posY + moveY));
+				addChunk(current, Chunk.getChunk(posX + moveX, posY + moveYPrev));
+			}
+
+			if (chunksAdded == 0)
+				break;
+
+			// sort the chunks by distance from the ray
+			Arrays.sort(chunkCache, 0, chunksAdded);
+
+			for (int i = 0; i < chunksAdded; i++)
+			{
+				Chunk chunk = chunkCache[i];
+				if (chunk == null)
+					continue;
+
+				totalChunksChecked++;
+
+				if (Chunk.debug && trace)
+				{
+					// displays the order of chunks checked and locations that the ray checked
+					Game.effects.add(Effect.createNewEffect(
+							(chunk.chunkX + 0.5) * Chunk.chunkSize * Game.tile_size + (totalChunksChecked * 15),
+							(chunk.chunkY + 0.5) * Chunk.chunkSize * Game.tile_size,
+							150, Effect.EffectType.chain, 90
+					).setRadius(totalChunksChecked));
+
+					Game.effects.add(Effect.createNewEffect(posX + moveX, posY + moveY, 20, Effect.EffectType.laser));
+
+					if (mid == null || current.manhattanDist(mid) > 1)
+					{
+						Game.effects.add(Effect.createNewEffect(posX, posY + moveY, 20, Effect.EffectType.obstaclePiece));
+						Game.effects.add(Effect.createNewEffect(posX + moveX, posY, 20, Effect.EffectType.piece));
+					}
+				}
+
+				checkCollisionIn(result, chunk.faces, firstBounce);
+
+				if (result.collisionFace != null)
+					break chunkCheck;
+			}
+		}
+	}
+
+	public boolean testInsideObstacle(double x, double y)
+	{
+		return isInsideObstacle(x - size / 2, y - size / 2) ||
+				isInsideObstacle(x + size / 2, y - size / 2) ||
+				isInsideObstacle(x + size / 2, y + size / 2) ||
+				isInsideObstacle(x - size / 2, y + size / 2);
+	}
+
+	public void checkCollisionIn(Result result, Chunk.FaceList faceList, boolean firstBounce)
+	{
+		Face collisionFace = null;
+		double t = Double.MAX_VALUE;
+		boolean corner = false;
+		double collisionX = 0, collisionY = 0;
+
+		if (vX > 0)
+		{
+			for (Face f : faceList.leftFaces)
+			{
+				double size = this.size;
+
+				if (f.owner instanceof Movable)
+					size *= tankHitSizeMul;
+				if (f.owner != null && f.owner == targetTank)
+					size *= targetTankSizeMul;
+
+				if (passesThrough(f, firstBounce) || f.startX < this.posX + size / 2)
+					continue;
+
+				double y = (f.startX - size / 2 - this.posX) * vY / vX + this.posY;
+				if (y >= f.startY - size / 2 && y <= f.endY + size / 2)
+				{
+					t = (f.startX - size / 2 - this.posX) / vX;
+					collisionX = f.startX - size / 2;
+					collisionY = y;
+					collisionFace = f;
+					break;
+				}
+			}
+		}
+		else if (vX < 0)
+		{
+			for (Face f : faceList.rightFaces)
+			{
+				double size = this.size;
+
+				if (f.owner instanceof Movable)
+					size *= tankHitSizeMul;
+
+				if (passesThrough(f, firstBounce) || f.startX > this.posX - size / 2)
+					continue;
+
+				double y = (f.startX + size / 2 - this.posX) * vY / vX + this.posY;
+				if (y >= f.startY - size / 2 && y <= f.endY + size / 2)
+				{
+					t = (f.startX + size / 2 - this.posX) / vX;
+					collisionX = f.startX + size / 2;
+					collisionY = y;
+					collisionFace = f;
+					break;
+				}
+			}
 		}
 
-		return dist;
+		if (vY > 0)
+		{
+			for (Face f : faceList.topFaces)
+			{
+				double size = this.size;
+
+				if (f.owner instanceof Movable)
+					size *= tankHitSizeMul;
+
+				if (passesThrough(f, firstBounce) || f.startY < this.posY + size / 2)
+					continue;
+
+				double x = (f.startY - size / 2 - this.posY) * vX / vY + this.posX;
+				if (x >= f.startX - size / 2 && x <= f.endX + size / 2)
+				{
+					double t1 = (f.startY - size / 2 - this.posY) / vY;
+
+					if (t1 == t)
+						corner = true;
+					else if (t1 < t)
+					{
+						collisionX = x;
+						collisionY = f.startY - size / 2;
+						collisionFace = f;
+						t = t1;
+					}
+					break;
+				}
+			}
+		}
+		else if (vY < 0)
+		{
+			for (Face f : faceList.bottomFaces)
+			{
+				double size = this.size;
+
+				if (f.owner instanceof Movable)
+					size *= tankHitSizeMul;
+
+				if (passesThrough(f, firstBounce) || f.startY > this.posY - size / 2)
+					continue;
+
+				double x = (f.startY + size / 2 - this.posY) * vX / vY + this.posX;
+				if (x >= f.startX - size / 2 && x <= f.endX + size / 2)
+				{
+					double t1 = (f.startY + size / 2 - this.posY) / vY;
+
+					if (t1 == t)
+						corner = true;
+					else if (t1 < t)
+					{
+						collisionX = x;
+						collisionY = f.startY + size / 2;
+						collisionFace = f;
+						t = t1;
+					}
+					break;
+				}
+			}
+		}
+
+		result.set(t, collisionX, collisionY, collisionFace, corner);
+	}
+
+	public boolean passesThrough(Face f, boolean firstBounce)
+	{
+		if ((asBullet ? !f.solidBullet : !f.solidTank) ||
+				(f.owner == tank && firstBounce))
+			return true;
+
+		if (f.owner instanceof Obstacle && !((Obstacle) f.owner).bouncy)
+		{
+			Obstacle o = (Obstacle) f.owner;
+			return (this.ignoreDestructible && o.destructible) || (this.ignoreShootThrough && o.shouldShootThrough);
+		}
+
+		return (ignoreTanks && f.owner instanceof Tank) || (ignoreBullets && f.owner instanceof Bullet);
+	}
+
+	public static final class Result
+	{
+		private double t, collisionX, collisionY;
+		private Face collisionFace;
+		private boolean corner;
+
+		public void set(double t, double collisionX, double collisionY, Face collisionFace, boolean corner)
+		{
+			this.t = t;
+			this.collisionX = collisionX;
+			this.collisionY = collisionY;
+			this.collisionFace = collisionFace;
+			this.corner = corner;
+		}
+	}
+
+	public double getDist()
+	{
+		this.bounceX.add(this.posX);
+		this.bounceY.add(this.posY);
+
+		if (!acquiredTarget)
+			this.getTarget();
+
+		return Math.sqrt(getSquaredFinalDist());
 	}
 
 	public double getTargetDist(double mul, Tank m)
 	{
+		return Math.sqrt(getSquaredTargetDist(mul, m));
+	}
+
+	public double getSquaredTargetDist(double mul, Tank m)
+	{
+		this.bounceX.add(0, this.posX);
+		this.bounceY.add(0, this.posY);
+
 		if (this.getTarget(mul, m) != m)
 			return -1;
 
+		return getSquaredFinalDist();
+	}
+
+	private double getSquaredFinalDist()
+	{
 		double dist = 0;
 		for (int i = 0; i < this.bounceX.size() - 1; i++)
-		{
-			dist += Math.sqrt(Math.pow(this.bounceX.get(i + 1) - this.bounceX.get(i), 2) + Math.pow(this.bounceY.get(i + 1) - this.bounceY.get(i), 2));
-		}
+			dist += Math.pow(this.bounceX.getDouble(i + 1) - this.bounceX.getDouble(i), 2) + Math.pow(this.bounceY.getDouble(i + 1) - this.bounceY.getDouble(i), 2);
+
+		if (this.bounces >= 0)
+			dist += Chunk.chunkToPixel(maxChunkCheck);
 
 		return dist;
+	}
+
+	private void addChunk(Chunk compare, Chunk c)
+	{
+		if (c == null || (chunksAdded > 0 && c == chunkCache[chunksAdded - 1]))
+			return;
+
+		c.compareTo = compare;
+		chunkCache[chunksAdded++] = c;
 	}
 
 	public double getAngleInDirection(double x, double y)
@@ -503,30 +619,17 @@ public class Ray
 		x -= this.posX;
 		y -= this.posY;
 
-		double angle = 0;
-		if (x > 0)
-			angle = Math.atan(y/x);
-		else if (x < 0)
-			angle = Math.atan(y/x) + Math.PI;
-		else
-		{
-			if (y > 0)
-				angle = Math.PI / 2;
-			else if (y < 0)
-				angle = Math.PI * 3 / 2;
-		}
-
-		return angle;
+		return Movable.getPolarDirection(x, y);
 	}
 
-	public static boolean isInsideObstacle(double x, double y)
+	public boolean isInsideObstacle(double x, double y)
 	{
-		return Game.isSolid(x, y);
+		Obstacle o = Game.getObstacle(x, y);
+		return o != null && collision(o) && !(ignoreShootThrough && o.shouldShootThrough) && !(ignoreDestructible && o.destructible);
 	}
 
-	public void moveOut(double amount)
+	public boolean collision(Obstacle o)
 	{
-		this.posX += this.vX * amount;
-		this.posY += this.vY * amount;
+		return asBullet ? o.bulletCollision : o.tankCollision;
 	}
 }

--- a/src/main/java/tanks/tank/Tank.java
+++ b/src/main/java/tanks/tank/Tank.java
@@ -1159,7 +1159,7 @@ public abstract class Tank extends Movable implements ISolidObject
 
 				if (dist > farthestInSight)
 				{
-					Ray r = new Ray(this.posX, this.posY, 0, 0, this);
+					Ray r = Ray.newRay(this.posX, this.posY, 0, 0, this);
 					r.vX = m.posX - this.posX;
 					r.vY = m.posY - this.posY;
 

--- a/src/main/java/tanks/tank/TankAIControlled.java
+++ b/src/main/java/tanks/tank/TankAIControlled.java
@@ -736,7 +736,7 @@ public class TankAIControlled extends Tank implements ITankField
 					if (this.targetEnemy != null && !(b instanceof BulletInstant) && this.enablePredictiveFiring && (this.shootAIType == ShootAI.straight || straightShoot))
 						an = this.getAngleInDirection(this.targetEnemy.posX, this.targetEnemy.posY);
 
-					Ray a2 = new Ray(this.posX, this.posY, an, b.bounces, this);
+					Ray a2 = Ray.newRay(this.posX, this.posY, an, b.bounces, this);
 					a2.size = b.size;
 					a2.getTarget();
 					a2.ignoreDestructible = this.aimIgnoreDestructible;
@@ -808,7 +808,7 @@ public class TankAIControlled extends Tank implements ITankField
 
 	public void finalCheckAndShoot(double offset)
 	{
-		Ray a = new Ray(this.posX, this.posY, this.angle + offset, this.getBullet().bounces, this, 2.5);
+		Ray a = Ray.newRay(this.posX, this.posY, this.angle + offset, this.getBullet().bounces, this, 2.5);
 		a.size = this.getBullet().size;
 		a.moveOut(this.size / 2.5);
 
@@ -828,7 +828,7 @@ public class TankAIControlled extends Tank implements ITankField
 		{
 			double offset2 = (i - ((this.shotRoundCount - 1) / 2.0)) / this.shotRoundCount * (this.shotRoundSpread * Math.PI / 180);
 
-			Ray a = new Ray(this.posX, this.posY, this.angle + offset + offset2, this.getBullet().bounces, this, 2.5);
+			Ray a = Ray.newRay(this.posX, this.posY, this.angle + offset + offset2, this.getBullet().bounces, this, 2.5);
 			a.size = this.getBullet().size;
 			a.moveOut(this.size / 2.5);
 
@@ -969,7 +969,7 @@ public class TankAIControlled extends Tank implements ITankField
 				if (m instanceof Tank && !(m instanceof TankAIControlled && ((TankAIControlled) m).transformMimic) && (((Tank) m).getTopLevelPossessor() == null || !(((Tank) m).getTopLevelPossessor().getClass().equals(this.getClass())))
 						&& ((Tank) m).currentlyTargetable && GameObject.distanceBetween(m, this) < nearestDist && ((Tank) m).size == this.size && !m.destroy)
 				{
-					Ray r = new Ray(this.posX, this.posY, this.getAngleInDirection(m.posX, m.posY), 0, this);
+					Ray r = Ray.newRay(this.posX, this.posY, this.getAngleInDirection(m.posX, m.posY), 0, this);
 					r.moveOut(5);
 					if (r.getTarget() != m)
 						continue;
@@ -1143,7 +1143,7 @@ public class TankAIControlled extends Tank implements ITankField
 
 			if (!this.overrideDirection && this.gentleTurnCooldown <= 0)
 			{
-				Ray d = new Ray(this.posX, this.posY, this.getPolarDirection(), 0, this, Game.tile_size);
+				Ray d = Ray.newRay(this.posX, this.posY, this.getPolarDirection(), 0, this, Game.tile_size);
 				d.size = Game.tile_size * this.hitboxSize - 1;
 
 				lastDistanceToWall = d.getDist();
@@ -1175,7 +1175,7 @@ public class TankAIControlled extends Tank implements ITankField
 
 			for (double dir = 0; dir < 4; dir += 0.5)
 			{
-				Ray r = new Ray(this.posX, this.posY, dir * Math.PI / 2, 0, this, Game.tile_size);
+				Ray r = Ray.newRay(this.posX, this.posY, dir * Math.PI / 2, 0, this, Game.tile_size);
 				r.size = Game.tile_size * this.hitboxSize - 1;
 				double dist = r.getDist() / Game.tile_size;
 
@@ -1516,7 +1516,7 @@ public class TankAIControlled extends Tank implements ITankField
 
 					for (int dir = 0; dir < count; dir++)
 					{
-						Ray r = new Ray(this.posX, this.posY, direction + fleeDirections[dir], 0, this, Game.tile_size);
+						Ray r = Ray.newRay(this.posX, this.posY, direction + fleeDirections[dir], 0, this, Game.tile_size);
 						r.size = Game.tile_size * this.hitboxSize - 1;
 
 						boolean b = this.targetEnemy != null && this.bulletAvoidBehvavior == BulletAvoidBehavior.aggressive_dodge && GameObject.absoluteAngleBetween(fleeDirections[dir] + direction, this.getAngleInDirection(this.targetEnemy.posX, this.targetEnemy.posY)) > Math.PI * 0.5;
@@ -1573,7 +1573,7 @@ public class TankAIControlled extends Tank implements ITankField
 					else if (this.bulletAvoidBehvavior == BulletAvoidBehavior.back_off_dodge)
 					{
 						double a = nearest.getAngleInDirection(this.posX, this.posY);
-						Ray r = new Ray(this.posX, this.posY, a, 0, this, Game.tile_size);
+						Ray r = Ray.newRay(this.posX, this.posY, a, 0, this, Game.tile_size);
 						r.size = Game.tile_size * this.hitboxSize - 1;
 						double d = r.getDist();
 
@@ -1593,7 +1593,7 @@ public class TankAIControlled extends Tank implements ITankField
 						if (Math.abs(diff) < Math.PI / 4)
 							this.avoidDirection = direction + Math.signum(diff) * Math.PI / 4;
 
-						Ray r = new Ray(this.posX, this.posY, this.avoidDirection, 0, this, Game.tile_size);
+						Ray r = Ray.newRay(this.posX, this.posY, this.avoidDirection, 0, this, Game.tile_size);
 						r.size = Game.tile_size * this.hitboxSize - 1;
 						double d = r.getDist();
 
@@ -1726,7 +1726,7 @@ public class TankAIControlled extends Tank implements ITankField
 		Bullet b = this.getBullet();
 		if (useRaysThisFrame)
 		{
-			Ray a = new Ray(this.posX, this.posY, this.angle, b.bounces, this);
+			Ray a = Ray.newRay(this.posX, this.posY, this.angle, b.bounces, this);
 			a.moveOut(this.size / 10);
 			a.size = b.size;
 			a.ignoreDestructible = this.aimIgnoreDestructible;
@@ -1852,7 +1852,7 @@ public class TankAIControlled extends Tank implements ITankField
 		{
 			if (useRaysThisFrame)
 			{
-				Ray r = new Ray(targetEnemy.posX, targetEnemy.posY, targetEnemy.getLastPolarDirection(), 0, (Tank) targetEnemy);
+				Ray r = Ray.newRay(targetEnemy.posX, targetEnemy.posY, targetEnemy.getLastPolarDirection(), 0, (Tank) targetEnemy);
 				r.ignoreDestructible = this.aimIgnoreDestructible;
 				r.ignoreShootThrough = true;
 				r.size = Game.tile_size * this.hitboxSize - 1;
@@ -1895,7 +1895,7 @@ public class TankAIControlled extends Tank implements ITankField
 		{
 			if (useRaysThisFrame)
 			{
-				Ray r = new Ray(targetEnemy.posX, targetEnemy.posY, targetEnemy.getLastPolarDirection(), 0, (Tank) targetEnemy);
+				Ray r = Ray.newRay(targetEnemy.posX, targetEnemy.posY, targetEnemy.getLastPolarDirection(), 0, (Tank) targetEnemy);
 				r.size = Game.tile_size * this.hitboxSize - 1;
 				r.enableBounciness = false;
 				this.disableOffset = false;
@@ -1976,7 +1976,7 @@ public class TankAIControlled extends Tank implements ITankField
 
 		if (this.targetEnemy != null && !arc)
 		{
-			Ray r = new Ray(this.posX, this.posY, this.getAngleInDirection(this.targetEnemy.posX, this.targetEnemy.posY), 0, this);
+			Ray r = Ray.newRay(this.posX, this.posY, this.getAngleInDirection(this.targetEnemy.posX, this.targetEnemy.posY), 0, this);
 			r.moveOut(this.size / 10);
 			r.size = b.size;
 			r.ignoreDestructible = this.aimIgnoreDestructible;
@@ -2087,7 +2087,7 @@ public class TankAIControlled extends Tank implements ITankField
 	public void testSearch(double searchAngle)
 	{
 		Bullet b = this.getBullet();
-		Ray ray = new Ray(this.posX, this.posY, searchAngle, b.bounces, this);
+		Ray ray = Ray.newRay(this.posX, this.posY, searchAngle, b.bounces, this);
 		ray.moveOut(this.size / 10);
 		ray.size = b.size;
 		ray.ignoreDestructible = this.aimIgnoreDestructible;
@@ -2100,7 +2100,7 @@ public class TankAIControlled extends Tank implements ITankField
 
 		if (target == null && this.shootAIType == ShootAI.homing && this.targetEnemy != null && inRange)
 		{
-			Ray ray2 = new Ray(ray.posX, ray.posY, ray.getAngleInDirection(this.targetEnemy.posX, this.targetEnemy.posY), 0, this);
+			Ray ray2 = Ray.newRay(ray.posX, ray.posY, ray.getAngleInDirection(this.targetEnemy.posX, this.targetEnemy.posY), 0, this);
 			ray2.moveOut(this.size / 50);
 			ray2.size = b.size;
 			ray2.ignoreDestructible = this.aimIgnoreDestructible;
@@ -2130,7 +2130,7 @@ public class TankAIControlled extends Tank implements ITankField
 
 		a = this.getAngleInDirection(this.targetEnemy.posX, this.targetEnemy.posY);
 
-		Ray rayToTarget = new Ray(this.posX, this.posY, a, 0, this);
+		Ray rayToTarget = Ray.newRay(this.posX, this.posY, a, 0, this);
 		rayToTarget.size = this.getBullet().size;
 		rayToTarget.moveOut(this.size / 10);
 		rayToTarget.ignoreDestructible = this.aimIgnoreDestructible;
@@ -2362,7 +2362,7 @@ public class TankAIControlled extends Tank implements ITankField
 		int k = 0;
 		for (double dir = 0; dir < 4; dir += 4.0 / count)
 		{
-			Ray r = new Ray(this.posX, this.posY, dir * Math.PI / 2, 0, this, Game.tile_size);
+			Ray r = Ray.newRay(this.posX, this.posY, dir * Math.PI / 2, 0, this, Game.tile_size);
 			r.size = Game.tile_size * this.hitboxSize - 1;
 
 			double dist = r.getDist();
@@ -2612,7 +2612,7 @@ public class TankAIControlled extends Tank implements ITankField
 			if (this.transformTank.targetEnemy != null)
 			{
 				this.targetEnemy = this.transformTank.targetEnemy;
-				Ray r = new Ray(this.transformTank.posX, this.transformTank.posY, this.transformTank.getAngleInDirection(this.targetEnemy.posX, this.targetEnemy.posY), 0, this);
+				Ray r = Ray.newRay(this.transformTank.posX, this.transformTank.posY, this.transformTank.getAngleInDirection(this.targetEnemy.posX, this.targetEnemy.posY), 0, this);
 
 				r.moveOut(5);
 
@@ -2672,7 +2672,7 @@ public class TankAIControlled extends Tank implements ITankField
 		{
 			if (this.targetEnemy != null)
 			{
-				Ray r = new Ray(this.possessingTank.posX, this.possessingTank.posY, 0, 0, this);
+				Ray r = Ray.newRay(this.possessingTank.posX, this.possessingTank.posY, 0, 0, this);
 				r.vX = this.targetEnemy.posX - this.possessingTank.posX;
 				r.vY = this.targetEnemy.posY - this.possessingTank.posY;
 

--- a/src/main/java/tanks/tank/TankPlayer.java
+++ b/src/main/java/tanks/tank/TankPlayer.java
@@ -480,7 +480,7 @@ public class TankPlayer extends TankPlayable implements ILocalPlayerTank, IServe
 								baseOff = Math.toRadians(b.multishotSpread) * ((j * 1.0 / (b.shotCount - 1)) - 0.5);
 						}
 
-						Ray r = new Ray(this.posX, this.posY, this.angle + baseOff + spreadOff, 1, this);
+						Ray r = Ray.newRay(this.posX, this.posY, this.angle + baseOff + spreadOff, 1, this);
 						r.bounces = b.bounces;
 						r.size = b.size;
 						if (k != 0)
@@ -661,6 +661,7 @@ public class TankPlayer extends TankPlayable implements ILocalPlayerTank, IServe
 		}
 
 		Game.eventsOut.add(new EventLayMine(m));
+		Game.avoidObjects.add(m);
 		Game.movables.add(m);
 	}
 


### PR DESCRIPTION
Delete the old implementation, use the new implementation

Features:
- Rewrote ray tracing for much better performance
- Chunk-separated obstacles and movables for more efficient filtering
- Faces are only updated when necessary (instead of every frame)
- Lots of utility methods to make interacting with the system easy

Misc changes:
- Added some chain methods to `Effect` to allow for concise one-liners
- Change removeMovables, removeObstacles, removeEffects, etc. to `ObjectArraySet`s (brute force array-based implementation of a set) to reduce hash table overhead during iteration

Coming next PR:
- Obstacle face culling
- Obstacle update culling
- Use new functions to further speed up obstacle and movable filtering