### PR TITLE
fix: add raycasting to check if target enemy candidates are in los

### DIFF
--- a/src/main/java/tanks/tank/Ray.java
+++ b/src/main/java/tanks/tank/Ray.java
@@ -72,7 +72,7 @@ public class Ray extends GameObject
     }
 
     /** Comparator that sorts the chunks by manhattan distance from {@linkplain #startingChunk} */
-    private static final Comparator<Chunk> chunkComparator = (o1, o2) -> keyExtractor(o1) - keyExtractor(o2);
+    private static final Comparator<Chunk> chunkComparator = Comparator.comparingInt(Ray::keyExtractor);
 
     /** Should be consumed immediately via getTarget or getDist. Otherwise, use {@linkplain #copy()} */
     public static Ray newRay(double x, double y, double angle, int bounces, Tank tank)

--- a/src/main/java/tanks/tank/Tank.java
+++ b/src/main/java/tanks/tank/Tank.java
@@ -1368,6 +1368,11 @@ public abstract class Tank extends Movable implements ISolidObject, IDrawableLig
         return m instanceof Tank ? (Tank) m : null;
     }
 
+    protected boolean canTarget()
+    {
+        return targetable && currentlyTargetable && !hidden;
+    }
+
     public static class ClippedTile
     {
         public final int x;

--- a/src/main/java/tanks/tank/TankAIControlled.java
+++ b/src/main/java/tanks/tank/TankAIControlled.java
@@ -595,6 +595,12 @@ public class TankAIControlled extends Tank implements ITankField
     /** How often to shoot rays for AI calculations. */
     protected double rayFrequency = 5;
 
+    /** A cached comparator prioritizing target enemy tanks based on distance and support-tank-specific behavior */
+    protected Comparator<Movable> tankTargetComparator;
+
+    /** A cached comparator prioritizing tanks that have line of sight of the tank */
+    protected Comparator<Movable> hasLineOfSightComparator;
+
     /** The time since rays were used. Initially randomized to spread things out. */
     protected double timeSinceRaysUsed = Math.random() * rayFrequency;
 
@@ -1029,46 +1035,41 @@ public class TankAIControlled extends Tank implements ITankField
 
     public void updateTarget()
     {
+        if (!useRaysThisFrame)
+            return;
+
         if (this.transformMimic)
             if (this.updateTargetMimic())
                 return;
 
-        double nearestDist = Double.MAX_VALUE;
-        Movable nearest = null;
         this.hasTarget = false;
 
         Bullet b = this.getBullet();
 
-        boolean lowPriority = true;
-        for (int i = 0; i < Game.movables.size(); i++)
+        // LOWER PRIORITY VALUE = HIGHER PRIORITY (due to natural sort order of ints)
+        if (tankTargetComparator == null)
         {
-            Movable m = Game.movables.get(i);
-
-            boolean correctTeam = (this.isSupportTank() && Team.isAllied(this, m)) || (!this.isSupportTank() && !Team.isAllied(this, m));
-            if (m instanceof Tank && correctTeam && !((Tank) m).hidden && ((Tank) m).currentlyTargetable && m != this)
-            {
-                if (b.damage < 0 && ((Tank) m).health - ((Tank) m).baseHealth >= b.maxExtraHealth && b.maxExtraHealth > 0)
-                    continue;
-
-                boolean lowP = ((b.damage == 0 && b.boosting) && (m instanceof TankAIControlled && !((TankAIControlled) m).enableMovement));
-                if (!lowPriority && lowP)
-                    continue;
-
-                double dist = GameObject.distanceBetween(this, m);
-                if (dist < nearestDist || (lowPriority && !lowP))
-                {
-                    this.hasTarget = true;
-                    nearestDist = dist;
-                    nearest = m;
-                    lowPriority = lowP;
-                }
-            }
+            tankTargetComparator = Comparator.
+                <Movable>comparingInt(m -> (b.damage == 0 && b.boosting) && (m instanceof TankAIControlled && !((TankAIControlled) m).enableMovement) ? 1 : 0)  // boosting tank priority calculation
+                .thenComparing(m -> GameObject.sqDistBetw(this, m));
         }
+
+        if (hasLineOfSightComparator == null)
+        {
+            hasLineOfSightComparator = Comparator.comparingInt(m -> inLineOfSight(m) ? 0 : 1);
+        }
+
+        Movable nearest = Game.movables.stream()
+        .filter(m -> m instanceof Tank && ((Tank) m).canTarget() && !m.destroy &&   // is targetable tank
+            this.isSupportTank() == Team.isAllied(this, m) && m != this &&               // is correct team
+            !(b.damage < 0 && ((Tank) m).health - ((Tank) m).baseHealth >= b.maxExtraHealth && b.maxExtraHealth > 0))   // if healer tank, is tank health maxed out
+        .sorted(tankTargetComparator).limit(3).min(hasLineOfSightComparator).orElse(null);
 
         if (this.targetEnemy != nearest)
             this.cooldownStacks = 0;
 
         this.targetEnemy = nearest;
+        this.hasTarget = this.targetEnemy != null;
     }
 
     public boolean updateTargetMimic()
@@ -2383,6 +2384,13 @@ public class TankAIControlled extends Tank implements ITankField
 
             this.angle = (this.angle + Math.PI * 2) % (Math.PI * 2);
         }
+    }
+
+    public boolean inLineOfSight(GameObject other)
+    {
+        return Ray.newRay(this.posX, this.posY, this.getAngleInDirection(other.posX, other.posY), 0, this)
+            .setSize(this.getBullet().size).moveOut(this.size / 10).setExplosive(this.aimIgnoreDestructible)
+            .setShootThrough(true).getTarget() == other;
     }
 
     public void updateIdleTurret()


### PR DESCRIPTION
Added helper methods:
- Added tank `canTarget` method that checks whether the tank is targetable and not hidden
- Added TankAIControlled `inLineOfSight` method

These helper methods should be used in other parts of the code for simplification, but that's for another PR

Added target enemy filtering based on line of sight. basically what the new updateTarget method does:
1. Checks for `useRaysThisFrame`, skips if false
2. Finds the top 3 target enemy candidates based upon the logic in the old updateTarget method
3. Sorts them by whether they are in LOS or not     <--- logic changed for this step, everything else should behave the same as before hopefully